### PR TITLE
fix: 修复使用pnpm运行时报错的BUG

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^1.1.7",
     "@chakra-ui/react": "^1.8.5",
+    "@chakra-ui/theme-tools": "^1.3.6",
     "@choc-ui/paginator": "^3.4.0",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ts-md5": "^1.2.11"
   },
   "devDependencies": {
+    "@types/node": "^17.0.21",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.1.8",

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ToTop from './to-top';
 import Ss from './site-settings';
-import { Box } from '@chakra-ui/layout';
+import { Box } from '@chakra-ui/react';
 
 const Overlay = (props:any) => {
   return <Box className="overlay" zIndex="100">

--- a/src/components/overlay/to-top.tsx
+++ b/src/components/overlay/to-top.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from "@chakra-ui/button";
+import { IconButton } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
 import { FiArrowUp } from "react-icons/fi";
 

--- a/src/pages/list/layout/nav.tsx
+++ b/src/pages/list/layout/nav.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 import {
   Breadcrumb,
   BreadcrumbItem,

--- a/src/pages/list/preview/markdown.tsx
+++ b/src/pages/list/preview/markdown.tsx
@@ -1,9 +1,8 @@
 import React, { useContext, useEffect } from "react";
 import { FileProps, IContext } from "../context";
 import axios from "axios";
-import { useColorModeValue } from "@chakra-ui/color-mode";
-import { Spinner } from "@chakra-ui/spinner";
-import { Box, Center } from "@chakra-ui/layout";
+import { Spinner, useColorModeValue } from "@chakra-ui/react";
+import { Box, Center } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import useFileUrl from "../../../hooks/useFileUrl";
 import ReactMarkdown from "react-markdown";
@@ -58,7 +57,7 @@ const Markdown = ({ file, readme }: FileProps) => {
           setContent(res);
         } else {
           setContent(
-            "```" + file.name.split(".").pop() + "\n" + res + "\n" + "```"
+            "```" + file.name.split(".").pop() + "\n" + res + "\n" + "```",
           );
         }
       });
@@ -74,7 +73,9 @@ const Markdown = ({ file, readme }: FileProps) => {
       <Box w="full">
         {html && (
           <FormControl display="flex" alignItems="center" m="1">
-            <FormLabel htmlFor="render" mb="0">Render?</FormLabel>
+            <FormLabel htmlFor="render" mb="0">
+              Render?
+            </FormLabel>
             <Switch
               id="render"
               isChecked={render}

--- a/src/pages/list/preview/office.tsx
+++ b/src/pages/list/preview/office.tsx
@@ -1,6 +1,6 @@
-import { Box, Stack } from "@chakra-ui/layout";
+import { Box, Stack } from "@chakra-ui/react";
+import { useLocation } from "react-router-dom";
 import React, { lazy, useContext, useEffect } from "react";
-import { useLocation } from "react-router";
 import { FileProps, IContext } from "../context";
 import useUnfold from "../../../hooks/useUnfold";
 import request from "../../../utils/public";
@@ -33,13 +33,13 @@ const Office = ({ file }: FileProps) => {
     {
       name: "office",
       url: `https://view.officeapps.live.com/op/view.aspx?src=${encodeURIComponent(
-        url
+        url,
       )}`,
     },
     {
       name: "google",
       url: `https://docs.google.com/gview?url=${encodeURIComponent(
-        url
+        url,
       )}&embedded=true`,
     },
   ];
@@ -107,7 +107,7 @@ const Office = ({ file }: FileProps) => {
                   src={preview.url}
                   frameBorder="0"
                 />
-              )
+              ),
           )}
         </Box>
       )}

--- a/src/pages/manage/login.tsx
+++ b/src/pages/manage/login.tsx
@@ -9,7 +9,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router";
+import { useHistory } from "react-router-dom";
 import admin, { changeToken } from "../../utils/admin";
 
 const Login = () => {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -53,7 +53,7 @@ const overrides: ThemeOverride = {
 
 const theme = extendTheme(
   overrides,
-  withDefaultColorScheme({ colorScheme: "twitter" })
+  withDefaultColorScheme({ colorScheme: "twitter" }),
 );
 
 export default theme;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "baseUrl": "./",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["./src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,22 +2,31 @@ import { defineConfig } from "vite";
 import reactRefresh from "@vitejs/plugin-react-refresh";
 import pluginRewriteAll from "vite-plugin-rewrite-all";
 import { useDynamicPublicPath } from "vite-plugin-dynamic-publicpath";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "",
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "src"),
+    },
+  },
+
   plugins: [
     reactRefresh(),
     pluginRewriteAll(),
     useDynamicPublicPath(),
   ],
+
   build: {
     target: "es2015",
   },
+  
   define: {
     "process.env": {},
   },
-  server:{
-    host: "0.0.0.0"
-  }
+  server: {
+    host: "0.0.0.0",
+  },
 });


### PR DESCRIPTION
修复使用pnpm安装依赖时，运行会报错的问题

顺便加了个resolve alias，这样下次引入包的时候，可以直接用绝对路径了，比如
```typescript
// before
import Overlay from "../../../components/overlay";

//after 
import Overlay from "~/components/overlay";
```