### PR TITLE
feat: add aria2 support

### DIFF
--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -149,6 +149,10 @@ const zh = {
   "Backup": "备份",
   "Restore": "还原",
   "Virtual path": "虚拟路径",
+  "Send to Aria2": "发送到Aria2",
+  "Send {{number}} links to Aria2": "发送 {{number}} 个链接到Aria2",
+  "Can't download folder with Aria2": "Aria2不能下载文件夹",
+  "Sent": "已发送",
 }
 
 export default zh

--- a/src/pages/list/context.tsx
+++ b/src/pages/list/context.tsx
@@ -148,7 +148,7 @@ export const IContext = createContext<ContextProps>({
   setPage: () => {},
   hideFiles: [],
   aria2: { rpcUrl: "", rpcSecret: "" },
-  setAria2: () => { },
+  setAria2: () => {},
 });
 
 const IContextProvider = (props: any) => {
@@ -271,19 +271,13 @@ const IContextProvider = (props: any) => {
     admin.get("settings?group=1").then((resp) => {
       let res = resp.data;
       if (res.code === 200) {
-        let setting = res.data;
-        let url = setting.find((item: { key: string; }) =>
-          item.key === "Aria2 RPC url"
-        );
-        url = url ? url.value : "";
-        let secret = setting.find((item: { key: string; }) =>
-          item.key === "Aria2 RPC secret"
-        );
-        secret = secret ? secret.value : "";
+        let setting: Setting[] = res.data;
+        let url = setting.find((item) => item.key === "Aria2 RPC url");
+        let secret = setting.find((item) => item.key === "Aria2 RPC secret");
         setAria2({
-          rpcUrl: url,
-          rpcSecret: secret
-        })
+          rpcUrl: url?.value || "",
+          rpcSecret: secret?.value || "",
+        });
       }
     });
   }, []);

--- a/src/pages/list/context.tsx
+++ b/src/pages/list/context.tsx
@@ -272,17 +272,14 @@ const IContextProvider = (props: any) => {
       let res = resp.data;
       if (res.code === 200) {
         let setting = res.data;
-        let url = setting.filter((item: { key: string; }) =>
+        let url = setting.find((item: { key: string; }) =>
           item.key === "Aria2 RPC url"
-        ).map((item: { value: string; }) => {
-          return item.value;
-        });
-
-        let secret = setting.filter((item: { key: string; }) =>
+        );
+        url = url ? url.value : "";
+        let secret = setting.find((item: { key: string; }) =>
           item.key === "Aria2 RPC secret"
-        ).map((item: { value: string; }) => {
-          return item.value;
-        });
+        );
+        secret = secret ? secret.value : "";
         setAria2({
           rpcUrl: url,
           rpcSecret: secret

--- a/src/pages/list/context.tsx
+++ b/src/pages/list/context.tsx
@@ -82,6 +82,11 @@ interface Page {
   page_size: number;
 }
 
+interface Aria2 {
+  rpcUrl: string;
+  rpcSecret: string;
+}
+
 export interface ContextProps {
   files: File[];
   setFiles: (files: File[]) => void;
@@ -113,6 +118,8 @@ export interface ContextProps {
   page: Page;
   setPage: (page: Page) => void;
   hideFiles: RegExp[];
+  aria2: Aria2;
+  setAria2: (aria2: Aria2) => void;
 }
 
 export const IContext = createContext<ContextProps>({
@@ -140,6 +147,8 @@ export const IContext = createContext<ContextProps>({
   page: { page_num: 1, page_size: 30 },
   setPage: () => {},
   hideFiles: [],
+  aria2: { rpcUrl: "", rpcSecret: "" },
+  setAria2: () => { },
 });
 
 const IContextProvider = (props: any) => {
@@ -167,6 +176,11 @@ const IContextProvider = (props: any) => {
   const [page, setPage] = React.useState<Page>({
     page_num: 1,
     page_size: 30,
+  });
+
+  const [aria2, setAria2] = React.useState<Aria2>({
+    rpcUrl: "",
+    rpcSecret: "",
   });
 
   const [hideFiles, setHideFiles] = React.useState<RegExp[]>([]);
@@ -253,9 +267,34 @@ const IContextProvider = (props: any) => {
     });
   }, []);
 
+  const aria2Config = useCallback(() => {
+    admin.get("settings?group=1").then((resp) => {
+      let res = resp.data;
+      if (res.code === 200) {
+        let setting = res.data;
+        let url = setting.filter((item: { key: string; }) =>
+          item.key === "Aria2 RPC url"
+        ).map((item: { value: string; }) => {
+          return item.value;
+        });
+
+        let secret = setting.filter((item: { key: string; }) =>
+          item.key === "Aria2 RPC secret"
+        ).map((item: { value: string; }) => {
+          return item.value;
+        });
+        setAria2({
+          rpcUrl: url,
+          rpcSecret: secret
+        })
+      }
+    });
+  }, []);
+
   useEffect(() => {
     initialSettings();
     login();
+    aria2Config();
   }, []);
 
   const [showUnfold, setShowUnfold] = React.useState<boolean>(false);
@@ -309,6 +348,7 @@ const IContextProvider = (props: any) => {
         page,
         setPage,
         hideFiles,
+        aria2,
       }}
       {...props}
     />

--- a/src/pages/list/layout/files/contextmenu.tsx
+++ b/src/pages/list/layout/files/contextmenu.tsx
@@ -36,7 +36,6 @@ import Move, { MoveSelect } from "./menus/move";
 import Copy, { CopySelect } from "./menus/copy";
 import Refresh from "./menus/refresh";
 import { downloadWithAria2 } from "~/utils/aria2";
-import { isEmpty, isNil } from "lodash";
 
 export const MENU_ID = "list-menu";
 
@@ -185,7 +184,7 @@ const ContextMenu = () => {
                 }
                 content = getFileUrlDecode(file);
               }
-              if(isEmpty(aria2.rpcUrl) || isEmpty(aria2.rpcSecret)) {
+              if(!aria2.rpcUrl) {
                 toast({
                   title: t("Aria2 is not configured"),
                   status: "error",

--- a/src/pages/list/layout/files/contextmenu.tsx
+++ b/src/pages/list/layout/files/contextmenu.tsx
@@ -21,7 +21,7 @@ import {
   FcNumericalSorting12,
   FcClock,
   FcRefresh,
-  FcDownload
+  FcDownload,
 } from "react-icons/fc";
 import { MdDeleteForever } from "react-icons/md";
 import useFileUrl from "../../../../hooks/useFileUrl";
@@ -45,8 +45,15 @@ interface IsOpenSet {
 
 const ContextMenu = () => {
   const { t } = useTranslation();
-  const { sort, setSort, multiSelect, setMultiSelect, selectFiles, loggedIn, aria2 } =
-    useContext(IContext);
+  const {
+    sort,
+    setSort,
+    multiSelect,
+    setMultiSelect,
+    selectFiles,
+    loggedIn,
+    aria2,
+  } = useContext(IContext);
   const menuTheme = useColorModeValue(theme.light, theme.dark);
   const toast = useToast();
   const getFileUrl = useFileUrl();
@@ -159,58 +166,60 @@ const ContextMenu = () => {
                 : t("Download")}
             </Flex>
           </Item>
-          
-          <Item
-            disabled={isItemDisabled}
-            onClick={({ props }) => {
-              let content = "";
-              if (multiSelect) {
-                content = selectFiles
-                  .filter((file) => file.type !== 1)
-                  .map((file) => {
-                    return getFileUrlDecode(file);
-                  })
-                  .join("\n");
-              } else {
-                const file = props as File;
-                if (file.type === 1) {
+
+          {loggedIn && (
+            <Item
+              disabled={isItemDisabled}
+              onClick={({ props }) => {
+                let content = "";
+                if (multiSelect) {
+                  content = selectFiles
+                    .filter((file) => file.type !== 1)
+                    .map((file) => {
+                      return getFileUrlDecode(file);
+                    })
+                    .join("\n");
+                } else {
+                  const file = props as File;
+                  if (file.type === 1) {
+                    toast({
+                      title: t("Can't download folder with Aria2"),
+                      status: "warning",
+                      duration: 3000,
+                      isClosable: true,
+                    });
+                    return;
+                  }
+                  content = getFileUrlDecode(file);
+                }
+                if (!aria2.rpcUrl) {
                   toast({
-                    title: t("Can't download folder with Aria2"),
-                    status: "warning",
+                    title: t("Aria2 is not configured"),
+                    status: "error",
                     duration: 3000,
                     isClosable: true,
                   });
-                  return;
+                } else {
+                  downloadWithAria2(content, aria2);
+                  toast({
+                    title: t("Sent"),
+                    status: "success",
+                    duration: 3000,
+                    isClosable: true,
+                  });
                 }
-                content = getFileUrlDecode(file);
-              }
-              if(!aria2.rpcUrl) {
-                toast({
-                  title: t("Aria2 is not configured"),
-                  status: "error",
-                  duration: 3000,
-                  isClosable: true,
-                });
-              } else {
-                downloadWithAria2(content, aria2);
-                toast({
-                  title: t("Sent"),
-                  status: "success",
-                  duration: 3000,
-                  isClosable: true,
-                });
-              }
-            }}
-          >
-            <Flex align="center">
-              <Icon as={FcDownload} boxSize={5} mr={2} />
-              {multiSelect
-                ? t("Send {{number}} links to Aria2", {
-                    number: selectFiles.length,
-                  })
-                : t("Send to Aria2")}
-            </Flex>
-          </Item>
+              }}
+            >
+              <Flex align="center">
+                <Icon as={FcDownload} boxSize={5} mr={2} />
+                {multiSelect
+                  ? t("Send {{number}} links to Aria2", {
+                      number: selectFiles.length,
+                    })
+                  : t("Send to Aria2")}
+              </Flex>
+            </Item>
+          )}
 
           <Item
             disabled={isItemDisabled}

--- a/src/utils/aria2.ts
+++ b/src/utils/aria2.ts
@@ -6,8 +6,8 @@ export const downloadWithAria2 = (content: string, aria2: { rpcUrl: string; rpcS
     if (linkArr.length > 0) {
         let url = aria2.rpcUrl;
         let secret = aria2.rpcSecret
-        if (!(url && secret)) {
-            console.log("aria2 url 和 token 不能为空");
+        if (!(url)) {
+            console.log("rpcUrl 不能为空");
         } else {
             for (let link of linkArr) {
                 let id = md5_16(link);
@@ -20,7 +20,6 @@ export const downloadWithAria2 = (content: string, aria2: { rpcUrl: string; rpcS
                         [link]
                     ]
                 }
-                console.log(data);
                 axios
                     .post(url, data)
                     .then(async (resp) => {

--- a/src/utils/aria2.ts
+++ b/src/utils/aria2.ts
@@ -1,0 +1,33 @@
+import axios from "axios";
+import { md5_16 } from "./md5";
+
+export const downloadWithAria2 = (content: string, aria2: { rpcUrl: string; rpcSecret: string; }) => {
+    let linkArr: string[] = content.split('\n');
+    if (linkArr.length > 0) {
+        let url = aria2.rpcUrl;
+        let secret = aria2.rpcSecret
+        if (!(url && secret)) {
+            console.log("aria2 url 和 token 不能为空");
+        } else {
+            for (let link of linkArr) {
+                let id = md5_16(link);
+                let data = {
+                    "id": id,
+                    "jsonrpc": "2.0",
+                    "method": "aria2.addUri",
+                    "params": [
+                        "token:" + secret,
+                        [link]
+                    ]
+                }
+                console.log(data);
+                axios
+                    .post(url, data)
+                    .then(async (resp) => {
+                        let res = resp.data;
+                        console.log(res)
+                    });
+            }
+        }
+    }
+};

--- a/src/utils/aria2.ts
+++ b/src/utils/aria2.ts
@@ -1,32 +1,30 @@
 import axios from "axios";
 import { md5_16 } from "./md5";
 
-export const downloadWithAria2 = (content: string, aria2: { rpcUrl: string; rpcSecret: string; }) => {
-    let linkArr: string[] = content.split('\n');
-    if (linkArr.length > 0) {
-        let url = aria2.rpcUrl;
-        let secret = aria2.rpcSecret
-        if (!(url)) {
-            console.log("rpcUrl 不能为空");
-        } else {
-            for (let link of linkArr) {
-                let id = md5_16(link);
-                let data = {
-                    "id": id,
-                    "jsonrpc": "2.0",
-                    "method": "aria2.addUri",
-                    "params": [
-                        "token:" + secret,
-                        [link]
-                    ]
-                }
-                axios
-                    .post(url, data)
-                    .then(async (resp) => {
-                        let res = resp.data;
-                        console.log(res)
-                    });
-            }
-        }
+export const downloadWithAria2 = (
+  content: string,
+  aria2: { rpcUrl: string; rpcSecret: string }
+) => {
+  let linkArr: string[] = content.split("\n");
+  if (linkArr.length > 0) {
+    let url = aria2.rpcUrl;
+    let secret = aria2.rpcSecret;
+    if (!url) {
+      console.log("rpcUrl 不能为空");
+    } else {
+      for (let link of linkArr) {
+        let id = md5_16(link);
+        let data = {
+          id: id,
+          jsonrpc: "2.0",
+          method: "aria2.addUri",
+          params: ["token:" + secret, [link]],
+        };
+        axios.post(url, data).then(async (resp) => {
+          let res = resp.data;
+          console.log(res);
+        });
+      }
     }
+  }
 };


### PR DESCRIPTION
在右键菜单中增加了使用aria2下载的item，可以直接发送选中的文件链接到aria2，aria2的配置在 setting->backend->(Aria2 RPC url, Aria2 RPC secret)