### PR TITLE
fix: 修复 aria2 异常文件名

### DIFF
--- a/src/utils/aria2.ts
+++ b/src/utils/aria2.ts
@@ -14,7 +14,7 @@ export const downloadWithAria2 = (
     } else {
       for (let link of linkArr) {
         let id = md5_16(link);
-        let fileNameArr: string[] = content.split("/");
+        let fileNameArr: string[] = link.split("/");
         let fileName = fileNameArr[fileNameArr.length - 1];
         let options = {
           out: fileName,

--- a/src/utils/aria2.ts
+++ b/src/utils/aria2.ts
@@ -14,11 +14,17 @@ export const downloadWithAria2 = (
     } else {
       for (let link of linkArr) {
         let id = md5_16(link);
+        let fileNameArr: string[] = content.split("/");
+        let fileName = fileNameArr[fileNameArr.length - 1];
+        let options = {
+          out: fileName,
+          "check-certificate": "false",
+        };
         let data = {
           id: id,
           jsonrpc: "2.0",
           method: "aria2.addUri",
-          params: ["token:" + secret, [link]],
+          params: ["token:" + secret, [link], options],
         };
         axios.post(url, data).then(async (resp) => {
           let res = resp.data;


### PR DESCRIPTION
按照 alist-org/alist#1187 所说 

> pikpak推送aria2下载时，名称默认为index.html

根据 [aria2 文档](https://github.com/aria2/aria2/blob/master/doc/manual-src/en/aria2c.rst#methods)，可以在请求中加 options (--out) 来[实现指定文件名](https://github.com/aria2/aria2/blob/master/doc/manual-src/en/aria2c.rst#httpftpsftp-options)


```
//before
{"id":"idididididid","jsonrpc":"2.0","method":"aria2.addUri","params":["token:",["下载链接"]]}

//after
{"id":"idididididid","jsonrpc":"2.0","method":"aria2.addUri","params":["token:",["下载链接"],{"out":"PikPak Tutorial.mp4","check-certificate":"false"}]}
```

